### PR TITLE
Improve offline compatibility of tests

### DIFF
--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -1,7 +1,39 @@
+import sys
+import types
+
+# Provide minimal stubs when optional dependencies are missing.  This
+# allows importing ``statsapi`` in environments without ``requests`` or
+# ``responses`` installed.
+try:  # pragma: no cover - used only when requests isn't installed
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - fallback for offline tests
+    requests = types.SimpleNamespace()
+
+    class HTTPError(Exception):
+        pass
+
+    requests.get = lambda *a, **k: None
+    requests.exceptions = types.SimpleNamespace(HTTPError=HTTPError)
+    sys.modules["requests"] = requests
+    sys.modules["requests.exceptions"] = requests.exceptions
+
+try:  # pragma: no cover - used only when responses isn't installed
+    import responses  # type: ignore
+except Exception:  # pragma: no cover - fallback for offline tests
+    responses = types.SimpleNamespace()
+    responses.GET = "GET"
+
+    def activate(fn=None):
+        return fn if fn is not None else (lambda f: f)
+
+    responses.activate = activate
+    responses.add = lambda *a, **k: None
+    sys.modules["responses"] = responses
+
 import statsapi
 import pytest
 import requests.exceptions
-import responses
+from unittest.mock import MagicMock
 
 
 def fake_dict():
@@ -23,11 +55,12 @@ def fake_dict():
     }
 
 
-def test_get_returns_dictionary(mocker):
+def test_get_returns_dictionary(monkeypatch):
     # mock the ENDPOINTS dictionary
-    mocker.patch.dict("statsapi.ENDPOINTS", fake_dict(), clear=True)
+    monkeypatch.setattr(statsapi, "ENDPOINTS", fake_dict())
     # mock the requests object
-    mock_req = mocker.patch("statsapi.requests", autospec=True)
+    mock_req = MagicMock()
+    monkeypatch.setattr(statsapi, "requests", mock_req)
     # mock the status code to always be 200
     mock_req.get.return_value.status_code = 200
 
@@ -36,31 +69,37 @@ def test_get_returns_dictionary(mocker):
     assert result == mock_req.get.return_value.json.return_value
 
 
-def test_get_calls_correct_url(mocker):
+def test_get_calls_correct_url(monkeypatch):
     # mock the ENDPOINTS dictionary
-    mocker.patch.dict("statsapi.ENDPOINTS", fake_dict(), clear=True)
+    monkeypatch.setattr(statsapi, "ENDPOINTS", fake_dict())
     # mock the requests object
-    mock_req = mocker.patch("statsapi.requests", autospec=True)
+    mock_req = MagicMock()
+    monkeypatch.setattr(statsapi, "requests", mock_req)
 
     statsapi.get("foo", {"bar": "baz"})
     mock_req.get.assert_called_with("http://www.foo.com?bar=baz")
 
 
-@responses.activate
-def test_get_server_error(mocker):
+def test_get_server_error(monkeypatch):
     # mock the ENDPOINTS dictionary
-    mocker.patch.dict("statsapi.ENDPOINTS", fake_dict(), clear=True)
-    responses.add(responses.GET, "http://www.foo.com?bar=baz", status=500)
+    monkeypatch.setattr(statsapi, "ENDPOINTS", fake_dict())
+    # mock the requests object to simulate a server error
+    mock_req = MagicMock()
+    monkeypatch.setattr(statsapi, "requests", mock_req)
+    mock_resp = mock_req.get.return_value
+    mock_resp.status_code = 500
+    mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError()
 
     with pytest.raises(requests.exceptions.HTTPError):
         statsapi.get("foo", {"bar": "baz"})
 
 
-def test_get_invalid_endpoint(mocker):
+def test_get_invalid_endpoint(monkeypatch):
     # mock the ENDPOINTS dictionary
-    mocker.patch.dict("statsapi.ENDPOINTS", fake_dict(), clear=True)
+    monkeypatch.setattr(statsapi, "ENDPOINTS", fake_dict())
     # mock the requests object
-    mock_req = mocker.patch("statsapi.requests", autospec=True)
+    mock_req = MagicMock()
+    monkeypatch.setattr(statsapi, "requests", mock_req)
     # invalid endpoint
     with pytest.raises(ValueError):
         statsapi.get("bar", {"foo": "baz"})


### PR DESCRIPTION
## Summary
- add lightweight stubs for `requests` and `responses` so `statsapi` can import without those dependencies
- remove reliance on `pytest-mock` by using `monkeypatch` and `unittest.mock`
- simulate HTTP errors directly via patched `statsapi.requests`

## Testing
- `pytest -q`