### PR TITLE
Add PowerShell install script

### DIFF
--- a/PowerShell/StatsApi/StatsApi.psd1
+++ b/PowerShell/StatsApi/StatsApi.psd1
@@ -1,0 +1,8 @@
+@{
+    RootModule = 'StatsApi.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = 'b7be47af-8ecd-4a02-a70b-dfbcb46a1be2'
+    Author = 'Project Contributors'
+    Description = 'PowerShell frontend for MLB-StatsAPI Python library.'
+    FunctionsToExport = @('*')
+}

--- a/PowerShell/StatsApi/StatsApi.psm1
+++ b/PowerShell/StatsApi/StatsApi.psm1
@@ -1,0 +1,61 @@
+function Invoke-StatsApiFunction {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$FunctionName,
+        [Hashtable]$Parameters = @{},
+        [string]$PythonPath = "python"
+    )
+
+    $json = $Parameters | ConvertTo-Json -Compress
+    $script = Join-Path $PSScriptRoot 'pswrapper.py'
+    $output = & $PythonPath $script $FunctionName --params $json 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "statsapi call failed: $output"
+    }
+    if ($output) {
+        return $output | ConvertFrom-Json
+    }
+}
+
+function Get-MLBSchedule {
+    [CmdletBinding()]
+    param(
+        [string]$Date,
+        [string]$StartDate,
+        [string]$EndDate,
+        [string]$Team,
+        [string]$Opponent,
+        [int]$SportId = 1,
+        [int]$GameId,
+        [string]$LeagueId,
+        [string]$Season,
+        [switch]$IncludeSeriesStatus
+    )
+    $params = @{}
+    if ($PSBoundParameters.ContainsKey('Date')) { $params['date'] = $Date }
+    if ($PSBoundParameters.ContainsKey('StartDate')) { $params['start_date'] = $StartDate }
+    if ($PSBoundParameters.ContainsKey('EndDate')) { $params['end_date'] = $EndDate }
+    if ($PSBoundParameters.ContainsKey('Team')) { $params['team'] = $Team }
+    if ($PSBoundParameters.ContainsKey('Opponent')) { $params['opponent'] = $Opponent }
+    if ($PSBoundParameters.ContainsKey('SportId')) { $params['sportId'] = $SportId }
+    if ($PSBoundParameters.ContainsKey('GameId')) { $params['game_id'] = $GameId }
+    if ($PSBoundParameters.ContainsKey('LeagueId')) { $params['leagueId'] = $LeagueId }
+    if ($PSBoundParameters.ContainsKey('Season')) { $params['season'] = $Season }
+    if ($IncludeSeriesStatus) { $params['include_series_status'] = $true }
+    Invoke-StatsApiFunction -FunctionName 'schedule' -Parameters $params
+}
+
+function Get-MLBBoxscore {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [int]$GamePk,
+        [string]$Timecode
+    )
+    $params = @{ 'gamePk' = $GamePk }
+    if ($PSBoundParameters.ContainsKey('Timecode')) { $params['timecode'] = $Timecode }
+    Invoke-StatsApiFunction -FunctionName 'boxscore' -Parameters $params
+}
+
+Export-ModuleMember -Function Invoke-StatsApiFunction, Get-MLBSchedule, Get-MLBBoxscore

--- a/PowerShell/StatsApi/pswrapper.py
+++ b/PowerShell/StatsApi/pswrapper.py
@@ -1,0 +1,31 @@
+import argparse
+import json
+import sys
+import statsapi
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PowerShell wrapper for statsapi")
+    parser.add_argument("function", help="Function name from statsapi to call")
+    parser.add_argument("--params", default="{}", help="JSON string of parameters")
+    args = parser.parse_args()
+
+    try:
+        params = json.loads(args.params)
+    except json.JSONDecodeError as exc:
+        print(f"Failed to parse parameters: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        func = getattr(statsapi, args.function)
+    except AttributeError:
+        print(f"Function '{args.function}' not found in statsapi", file=sys.stderr)
+        return 1
+
+    result = func(**params)
+    json.dump(result, sys.stdout, default=str)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/PowerShell/install_reqs.ps1
+++ b/PowerShell/install_reqs.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = 'Stop'
+$projRoot = Split-Path $PSScriptRoot -Parent
+pip install -r "$projRoot/requirements.txt"
+pip install -r "$projRoot/requirements-dev.txt"

--- a/README.md
+++ b/README.md
@@ -13,3 +13,18 @@ Wiki/Documentation: https://github.com/toddrob99/MLB-StatsAPI/wiki
 ## Copyright Notice
 
 This package and its author are not affiliated with MLB or any MLB team. This API wrapper interfaces with MLB's Stats API. Use of MLB data is subject to the notice posted at http://gdx.mlb.com/components/copyright.txt.
+
+## PowerShell Module
+
+A simple PowerShell module is provided in `PowerShell/StatsApi` to expose
+common functions from this library. It requires Python and this package to be
+available on the system. Import the module and then call the functions:
+
+Use `PowerShell/install_reqs.ps1` to install the Python dependencies if needed.
+
+```powershell
+Import-Module ./PowerShell/StatsApi/StatsApi.psd1
+$schedule = Get-MLBSchedule -Date "2024-05-01"
+```
+
+`Invoke-StatsApiFunction` can be used to access any other function by name.


### PR DESCRIPTION
## Summary
- add install_reqs.ps1 to install required Python packages for the PowerShell module
- document this helper script in the README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement pytest-mock)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'responses')*